### PR TITLE
support inserts of type 'object' and 'undefined'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@ coverage/*
 node_modules/
 npm-debug.log
 .vscode/*
-
+.idea/
 

--- a/README.md
+++ b/README.md
@@ -40,3 +40,15 @@ There is a simple application that always responds with a `catalogedError` in [e
 ```
 node example/errorMiddlewareApp/errorMiddlewareApp.js
 ```
+
+## Release Notes
+
+**v1.0.0**  
+
+- Initial release
+
+**v2.0.0**
+
+- Positional and named inserts can now be of type: undefined and object, in addition to string, number, boolean  
+  Objects and arrays will be stringified with the normal `toString()` 
+- `catalogedError` constructor will throw for unsupported insert types

--- a/lib/catalogedError.js
+++ b/lib/catalogedError.js
@@ -6,8 +6,23 @@
 
 'use strict';
 
+var messageCatalogManager = require("./message-catalog-manager.js");
+
 class catalogedError extends Error {
+
+    /**
+     * Construct a catalogedError
+     * @param {string}   messageNumber - message code
+     * @param {string}   catalog - catalog containing message
+     * @param {string}   message - debug message text
+     * @param {[object<string,*>]} namedInserts - optional map of named message inserts
+     * @param {[*[]]}    positionalInserts - optional array of positional message inserts
+     */
     constructor(messageNumber, catalog, message, namedInserts, positionalInserts) {
+
+        messageCatalogManager.internal.validateNamedInsertTypes(namedInserts);
+        messageCatalogManager.internal.validatePositionalInsertTypes(positionalInserts);
+
         super(message);
         this.messageNumber = messageNumber || "DEFAULT";
         this.catalog = catalog || "DEFAULT";

--- a/lib/message-catalog-manager.js
+++ b/lib/message-catalog-manager.js
@@ -68,16 +68,59 @@ MessageCatalogManager.prototype.checkCatalog = function (catalogName) {
 };
 
 var isInsertTypeValid = function (insert) {
-    return ["string", "number", "boolean"].indexOf(typeof insert) !== -1;
+    return ["string", "number", "boolean", "object", "undefined"].indexOf(typeof insert) !== -1;
+};
+
+/**
+ * Validate the value types in a map of named inserts
+ * @param {[object<string, *>]} namedInserts - optional map of named inserts
+ * @throws {Error} if type of an insert value is not supported
+ */
+var validateNamedInsertTypes = function (namedInserts){
+
+    if (namedInserts !== undefined){
+        if (typeof namedInserts !== 'object'){
+            throw new Error("named inserts must be an object if defined");
+        }
+        for (var key in namedInserts){
+            /* istanbul ignore else */
+            if (namedInserts.hasOwnProperty(key)) {
+                if (!isInsertTypeValid(namedInserts[key])) {
+                    throw new Error("namedInserts '" + key + "' is of unsupported type " + typeof namedInserts[key]);
+                }
+            }
+        }
+    }
+};
+
+/**
+ * Validate the value types in a map of positional inserts
+ * @param {[*[]]} positionalInserts - optional array of positional inserts
+ * @throws {Error} if type of an insert is not supported
+ */
+var validatePositionalInsertTypes = function (positionalInserts){
+    if (positionalInserts !== undefined) {
+        if (!Array.isArray(positionalInserts)) {
+            throw new Error("positional inserts must be an array if defined");
+        }
+        for (var position = 0; position < positionalInserts.length; position++) {
+            if (!isInsertTypeValid(positionalInserts[position])) {
+                throw new Error("positionalInserts value with index: '" + position + "' is of unsupported type " + typeof positionalInserts[position]);
+            }
+        }
+    }
 };
 
 var applyInserts = function (msg, namedInserts, positionalInserts) {
     var i;
     var re;
+
     //Replace positional inserts
-    for (i = 0; i < positionalInserts.length; i++) {
-        re = new RegExp("\\{" + i + "\\}", "gi");
-        msg = msg.replace(re, positionalInserts[i]);
+    if (positionalInserts) {
+        for (i = 0; i < positionalInserts.length; i++) {
+            re = new RegExp("\\{" + i + "\\}", "gi");
+            msg = msg.replace(re, positionalInserts[i]);
+        }
     }
 
     //Replace key inserts
@@ -121,20 +164,8 @@ MessageCatalogManager.prototype.getMessage = function (catalogName, code, namedI
     //clone the message
     var message = JSON.parse(JSON.stringify(msg));
 
-    for (var key in namedInserts){
-        /* istanbul ignore else */
-        if (namedInserts.hasOwnProperty(key)) {
-            if (!isInsertTypeValid(namedInserts[key])) {
-                throw new Error("namedInserts value: '" + key + "' must be of type string, number or boolean");
-            }
-        }
-    }
-
-    for (var position = 0; position < positionalInserts.length; position++) {
-        if (!isInsertTypeValid(positionalInserts[position])) {
-            throw new Error("positionalInserts value with index: '" + position + "' must be of type string, number or boolean");
-        }
-    }
+    validateNamedInsertTypes(namedInserts);
+    validatePositionalInsertTypes(positionalInserts);
 
     if (message.namedInserts) {
         message.namedInserts = _.extend(namedInserts, message.namedInserts);
@@ -169,7 +200,7 @@ MessageCatalogManager.prototype.getMessage = function (catalogName, code, namedI
 };
 
 MessageCatalogManager.prototype.getCatalogedErrorMessage = function (catalogedError) {
-    if (catalogedError.inserts != undefined && catalogedError.positionalInserts === undefined)
+    if (catalogedError.inserts !== undefined && catalogedError.positionalInserts === undefined)
     {
         //Tolerate V0 style catalogedError
         catalogedError.positionalInserts = catalogedError.inserts;
@@ -183,6 +214,8 @@ MessageCatalogManager.prototype.getCatalogedErrorMessage = function (catalogedEr
 module.exports = {
     MessageCatalogManager: MessageCatalogManager,
     internal: {
-        applyInserts: applyInserts
+        applyInserts: applyInserts,
+        validateNamedInsertTypes: validateNamedInsertTypes,
+        validatePositionalInsertTypes: validatePositionalInsertTypes
     }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "message-catalog-manager",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "message catalog manager",
   "engines": {
     "node": "4.4",

--- a/test/cataloged-error-test.js
+++ b/test/cataloged-error-test.js
@@ -54,4 +54,48 @@ describe('catalogedError testcases', function () {
             done();
         }
     });
+
+    it('constructor throws on unsupported named insert parameter', function () {
+        function createBadCatalogedError() {
+            var messageText = "Test Error";
+            var messagePositionalInserts = [1,2,3,4];
+            var catalog = "my-cat";
+            var messageNamedInserts = 'bad'; // should be object
+            new CatalogedError("1", catalog, messageText, messageNamedInserts, messagePositionalInserts);
+        }
+        expect(createBadCatalogedError).throws("named inserts must be an object if defined");
+    });
+
+    it('constructor throws on unsupported named insert type', function () {
+        function createBadCatalogedError() {
+            var messageText = "Test Error";
+            var messagePositionalInserts = [1,2,3,4];
+            var catalog = "my-cat";
+            var messageNamedInserts = {badInsert: function(){}};
+            new CatalogedError("1", catalog, messageText, messageNamedInserts, messagePositionalInserts);
+        }
+        expect(createBadCatalogedError).throws("namedInserts 'badInsert' is of unsupported type function");
+    });
+
+    it('constructor throws on unsupported positional insert parameter', function () {
+        function createBadCatalogedError() {
+            var messageText = "Test Error";
+            var messagePositionalInserts = {}; // should be array
+            var catalog = "my-cat";
+            var messageNamedInserts = {myInsert: 'myValue'};
+            new CatalogedError("1", catalog, messageText, messageNamedInserts, messagePositionalInserts);
+        }
+        expect(createBadCatalogedError).throws("positional inserts must be an array if defined");
+    });
+
+    it('constructor throws on unsupported positional insert type', function () {
+        function createBadCatalogedError() {
+            var messageText = "Test Error";
+            var messagePositionalInserts = [1,function(){},3];
+            var catalog = "my-cat";
+            var messageNamedInserts = {myInsert: 'myValue'};
+            new CatalogedError("1", catalog, messageText, messageNamedInserts, messagePositionalInserts);
+        }
+        expect(createBadCatalogedError).throws("positionalInserts value with index: '1' is of unsupported type function");
+    });
 });

--- a/test/errorMiddleware-test.js
+++ b/test/errorMiddleware-test.js
@@ -78,7 +78,7 @@ describe('errorMiddleware', function () {
                 nextCalled = true;
             });
             assert.isTrue(nextCalled);
-            var testError = new CatalogedError('0002','exampleLocal','Example error',[],{id:"EXAMPLE ID"});
+            var testError = new CatalogedError('0002','exampleLocal','Example error',{id:"EXAMPLE ID"},[]);
             res.send(testError);
             assert(originalSendSpy.calledOnce,"Send should have been called once");
             var spyArg = originalSendSpy.getCall(0).args[0];
@@ -95,7 +95,7 @@ describe('errorMiddleware', function () {
                 nextCalled = true;
             });
             assert.isTrue(nextCalled);
-            var testError = new CatalogedError('error','error','Example error',[],{id:"EXAMPLE ID"});
+            var testError = new CatalogedError('error','error','Example error',{id:"EXAMPLE ID"},[]);
             res.send(testError);
             assert(originalSendSpy.calledOnce,"Send should have been called once");
             assert(originalSendSpy.calledOnce,"Send should have been called once");

--- a/test/message-catalog-manager-test.js
+++ b/test/message-catalog-manager-test.js
@@ -23,76 +23,84 @@ describe('MessageCatalogManager', function () {
 
         it('returns a resolved message in the default locale', function () {
             var message = MC.getMessage("exampleLocal", "0001", {}, []);
-            console.log(JSON.stringify(message));
             expect(message.message).to.equal("This is an example message");
             expect(message.action).to.equal("Write a real message");
             expect(message.url).to.equal("https://github.com/IBM/message-catalog-manager/README.md");
         });
         it('returns a resolved message in the default locale with no action', function () {
             var message = MC.getMessage("exampleLocal", "0006", {}, []);
-            console.log(JSON.stringify(message));
             expect(message.message).to.equal("This is an example message with no action");
             expect(message.action).to.not.exist;
         });
         it('returns a resolved message in english locale', function () {
             var message = MC.getMessage("exampleLocal", "0001", {}, [], "en");
-            console.log(JSON.stringify(message));
             expect(message.message).to.equal("This is an example message");
         });
         it('returns a resolved message in a different locale', function () {
             var message = MC.getMessage("exampleLocal", "0001", {}, [], "jp");
-            console.log(JSON.stringify(message));
             expect(message.message).to.equal("This is an example message for japanese catalog");
         });
         it('returns a resolved message in the default locale if the given one does not exist', function () {
             var message = MC.getMessage("exampleLocal", "0001", {}, [], "ro");
-            console.log(JSON.stringify(message));
             expect(message.message).to.equal("This is an example message");
         });
         it('returns a resolved message in default locale when given a code that does not exist in a different locale', function () {
             var message = MC.getMessage("exampleLocal", "0004", {}, [], "de");
-            console.log(JSON.stringify(message));
             expect(message.message).to.equal("This is a message only in the default catalog");
         });
         it('returns a resolved message with special {id} insert in the default locale', function () {
             var message = MC.getMessage("exampleLocal", "0002", {id:"test-id", number: 0, boolean: true}, []);
-            console.log(JSON.stringify(message));
             expect(message.message).to.equal("This is an example message with a special insert test-id 0 true");
         });
         it('returns a resolved message with special {id} insert in english locale', function () {
             var message = MC.getMessage("exampleLocal", "0002", {id:"test-id-en", number: 1, boolean: false}, [], "en");
-            console.log(JSON.stringify(message));
             expect(message.message).to.equal("This is an example message with a special insert test-id-en 1 false");
         });
         it('returns a resolved message with special {id} insert in a different locale', function () {
             var message = MC.getMessage("exampleLocal", "0002", {id:"test-id-de"}, [], "de");
-            console.log(JSON.stringify(message));
             expect(message.message).to.equal("This is an example message with a special insert test-id-de, in german locale");
         });
         it('returns a resolved message with special {id} insert in the default locale if the given one does not exist', function () {
             var message = MC.getMessage("exampleLocal", "0002", {id:"test-id-ro", number: 1, boolean: false}, [], "ro");
-            console.log(JSON.stringify(message));
             expect(message.message).to.equal("This is an example message with a special insert test-id-ro 1 false");
         });
-        it('returns a resolved message with [positional inserts in the default locale', function () {
+        it('returns a resolved message with special {id} insert for non-string values', function () {
+            var message = MC.getMessage("exampleLocal", "0002", {id: null, number: NaN, boolean: undefined}, []);
+            expect(message.message).to.equal("This is an example message with a special insert null NaN undefined");
+        });
+        it('returns a resolved message with positional inserts in the default locale', function () {
             var message = MC.getMessage("exampleLocal", "0003", {}, ["one", 2, "three", true]);
-            console.log(JSON.stringify(message));
             expect(message.message).to.equal("This is an example message with positional inserts one 2 three true");
         });
-        it('returns a resolved message with [positional inserts in english locale', function () {
-            var message = MC.getMessage("exampleLocal", "0003", {}, [1, 2, "three", true], "en");
-            console.log(JSON.stringify(message));
+        it('returns a resolved message with positional inserts in english locale', function () {
+            var message = MC.getMessage("exampleLocal", "0003", {}, [1, 2, "three", true, null], "en");
             expect(message.message).to.equal("This is an example message with positional inserts 1 2 three true");
         });
-        it('returns a resolved message with [positional inserts in a different locale', function () {
+        it('returns a resolved message with positional inserts in a different locale', function () {
             var message = MC.getMessage("exampleLocal", "0003", {}, ["eins", "2", "drei"], "de");
-            console.log(JSON.stringify(message));
             expect(message.message).to.equal("This is an example message with positional inserts eins 2 drei, in german locale");
         });
-        it('returns a resolved message with [positional inserts in the default locale if the given one does not exist', function () {
+        it('returns a resolved message with positional inserts in the default locale if the given one does not exist', function () {
             var message = MC.getMessage("exampleLocal", "0003", {}, ["one", "2", "three", true], "ro");
-            console.log(JSON.stringify(message));
             expect(message.message).to.equal("This is an example message with positional inserts one 2 three true");
+        });
+        it('returns a resolved message with positional inserts for non-string values', function () {
+            var message = MC.getMessage("exampleLocal", "0003", {}, [null, undefined, NaN, Infinity]);
+            expect(message.message).to.equal("This is an example message with positional inserts null undefined NaN Infinity");
+        });
+        it('returns a resolved message with positional inserts that are objects stringified', function () {
+            var insertObj = {iam: 'an object'};
+            var insertEmptyObj = {};
+            var insertObjCustomToString = {toString: function(){return 'custom_to_string_value';}};
+            var message = MC.getMessage("exampleLocal", "0003", {}, ['ImAString', insertObj, insertEmptyObj, insertObjCustomToString]);
+            expect(message.message).to.equal("This is an example message with positional inserts ImAString [object Object] [object Object] custom_to_string_value");
+        });
+        it('returns a resolved message with positional inserts that are arrays stringified', function () {
+            var insertArr = ["item1", "item2"];
+            var insertEmptyArr = [];
+            var insertArrOfManyTypes = ["string", 123.4, {iam: 'an object'}, undefined, null];
+            var message = MC.getMessage("exampleLocal", "0003", undefined, [insertArr, insertEmptyArr, insertArrOfManyTypes, 'lastInsert']);
+            expect(message.message).to.equal("This is an example message with positional inserts item1,item2  string,123.4,[object Object],, lastInsert");
         });
         it('throws if message not matched in a valid catalog', function () {
             var test = function() { MC.getMessage("exampleLocal", "invalid_message"); };
@@ -107,28 +115,27 @@ describe('MessageCatalogManager', function () {
             expect(test).to.throw(Error, /Catalog wibble not found/);
         });
         it('returns additional information (namedInserts) if verbose option is set', function () {
-            var message =  MC.getMessage("exampleLocal", "0007", {foo:"bar"},{},"en", 1);
-            console.log(JSON.stringify(message));
+            var message =  MC.getMessage("exampleLocal", "0007", {foo:"bar"},[],"en", 1);
             expect(message.namedInserts).to.deep.equal({key:"value",foo:"bar"});
         });
-        it('throws an error if the value of namedInserts is not a string, a number or a boolean', function() {
-            var test = function () {MC.getMessage("exampleLocal", "0007", {foo:{}},{},"en", 1);};
-            expect(test).to.throw(Error, /namedInserts value: 'foo' must be of type string, number or boolean/);
+        it('throws an error if a namedInserts value has unsupported type', function() {
+            function myFunction(){}
+            var test = function () {MC.getMessage("exampleLocal", "0007", {myInsert: myFunction},{},"en", 1);};
+            expect(test).to.throw(Error, /namedInserts 'myInsert' is of unsupported type function/);
         });
 
-        it('throws an error if the value of positionalInserts is not a string, a number or a boolean', function() {
-            var test = function () {MC.getMessage("exampleLocal", "0007", {},[{}],"en", 1);};
-            expect(test).to.throw(Error, /positionalInserts value with index: '0' must be of type string, number or boolean/);
+        it('throws an error if a positionalInserts value has unsupported type', function() {
+            function myFunction(){}
+            var test = function () {MC.getMessage("exampleLocal", "0007", {},[myFunction],"en", 1);};
+            expect(test).to.throw(Error, /positionalInserts value with index: '0' is of unsupported type function/);
         });
 
         it('returns a combined notification context object if message.namedInserts exists', function() {
-            var message = MC.getMessage("exampleLocal", "0007", {foo:"bar", boo: true, num: 0}, {}, "en", 1);
-            console.log(JSON.stringify(message));
+            var message = MC.getMessage("exampleLocal", "0007", {foo:"bar", boo: true, num: 0}, [], "en", 1);
             expect(message.namedInserts).to.deep.equal({foo:"bar",boo: true, num: 0, key:"value"});
         });
         it('returns notification context object if message.namedInserts does not exists', function() {
-            var message = MC.getMessage("exampleLocal", "0001", {foo:"bar"}, {}, "en", 1);
-            console.log(JSON.stringify(message));
+            var message = MC.getMessage("exampleLocal", "0001", {foo:"bar"}, undefined, "en", 1);
             expect(message.namedInserts).to.deep.equal({foo:"bar"});
         });
 


### PR DESCRIPTION
Currently inserts (either positional or named) must be of type `number`, `string`, or `boolean`, and the typing is only checked in `getMessage`

This PR adds checking of insert types to the `catalogedError` constructor, for earlier feedback.
It also allows `undefined` and `object` types.

---

Signed-off-by: Mark Frost <frostmar@uk.ibm.com>