### PR TITLE
Formatting preprocess function

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 This module provides a mechanism for translating messages to provide user readable information. Messages support named and positional inserts to give context to the messages. Messages can include messages and actions, as well as urls for more information. A catloggedError class carries catalog message context information so errors thrown around a system can be translated at the appropriate point.
 
 ### Catalog file format
-The catalog manager works with a set of json message catalog files contain message text.  
-These are indexed in a separate catalog index file which is provided to the catalog manager.  
+The catalog manager works with a set of json message catalog files contain message text.
+These are indexed in a separate catalog index file which is provided to the catalog manager.
 
-For an example of the catalog file format see:  
-[messages.json](test/catalogs/example/messages.json)  
-For an example of the catalog index fileformat see:  
-[catalog-index.json](test/catalogs/example/index.js)  
+For an example of the catalog file format see:
+[messages.json](test/catalogs/example/messages.json)
+For an example of the catalog index fileformat see:
+[catalog-index.json](test/catalogs/example/index.js)
 
 ### Using messageCatalogManager
 ```js
@@ -36,19 +36,30 @@ If your Express application generates or receives a `catalogedError` you can use
 app.use(new ErrorFormattingMiddleware('catalog-index.json'));
 ```
 
-There is a simple application that always responds with a `catalogedError` in [example](/example). Start it like 
+There is a simple application that always responds with a `catalogedError` in [example](/example). Start it like
 ```
 node example/errorMiddlewareApp/errorMiddlewareApp.js
 ```
 
 ## Release Notes
 
-**v1.0.0**  
+**v1.0.0**
 
 - Initial release
 
 **v2.0.0**
 
-- Positional and named inserts can now be of type: undefined and object, in addition to string, number, boolean  
-  Objects and arrays will be stringified with the normal `toString()` 
+- Positional and named inserts can now be of type: undefined and object, in addition to string, number, boolean
+  Objects and arrays will be stringified with the normal `toString()`
 - `catalogedError` constructor will throw for unsupported insert types
+
+**v2.1.0**
+
+- ErrorFormattingMiddleware supports an optional function to transform messages before formatting:
+    ```js
+    function myTransform(msg){
+      // transform msg as required
+      return msg;
+    }
+    app.use(new ErrorFormattingMiddleware('catalog-index.json', myTransform));
+    ```

--- a/lib/middleware/errorMiddleware.js
+++ b/lib/middleware/errorMiddleware.js
@@ -11,12 +11,22 @@ let MessageCatalogManager = require('../message-catalog-manager.js').MessageCata
 let catalogManager;
 
 class CatalogedErrorFormatter {
-    constructor(catalogIndex) {
+
+    /**
+     * Construct a middleware function to format instances of CatalogedMessage
+     * @param {string} catalogIndex - path to message catalog file
+     * @param {function} [preProcessorFunction] - optional function to transform a message before formatting it
+     * @returns {function} - Express-compatible middleware function
+     */
+    constructor(catalogIndex, preProcessorFunction) {
+        var self = this;
         catalogManager = new MessageCatalogManager(catalogIndex);
-        return this.middleware;
+        return function(req,res,next) {
+            return self._middleware(req, res, next, preProcessorFunction);
+        };
     }
 
-    middleware(req, res, next) {
+    _middleware(req, res, next, preProcessorFunction) {
         var oldSend = res.send;
 
         res.send = function (data) {
@@ -25,6 +35,9 @@ class CatalogedErrorFormatter {
                 if ((res.statusCode >= 400 && res.statusCode <= 599) &&
                     data.messageNumber != undefined && data.catalog != undefined) {
 
+                    if(preProcessorFunction){
+                        data = preProcessorFunction(data);
+                    }
                     //Format
                     data = catalogManager.getCatalogedErrorMessage(data);
                 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "message-catalog-manager",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "message catalog manager",
   "engines": {
     "node": "4.4",

--- a/test/cataloged-error-test.js
+++ b/test/cataloged-error-test.js
@@ -31,7 +31,6 @@ describe('catalogedError testcases', function () {
             expect(err.messageNumber).to.equal("1");
             expect(err.message).to.equal(messageText);
             expect(err.catalog).to.equal(catalog);
-            console.log("Err:"+JSON.stringify(err));
             done();
         }
     });
@@ -50,7 +49,6 @@ describe('catalogedError testcases', function () {
             expect(err.messageNumber).to.equal("DEFAULT");
             expect(err.message).to.equal(messageText);
             expect(err.catalog).to.equal("DEFAULT");
-            console.log("Err:"+JSON.stringify(err));
             done();
         }
     });

--- a/test/errorMiddleware-test.js
+++ b/test/errorMiddleware-test.js
@@ -16,10 +16,9 @@ var CatalogedError = require('../lib/catalogedError.js');
 
 describe('errorMiddleware', function () {
 
-    it('can be constructed with a catalog index', function (done) {
+    it('can be constructed with a catalog index', function () {
         var testMiddleware = new Middleware(__dirname + '/catalog-index.json');
         assert.isFunction(testMiddleware);
-        done();
     });
 
     describe('function', function () {
@@ -44,7 +43,7 @@ describe('errorMiddleware', function () {
             originalSendSpy.restore();
         });
 
-        it('does nothing for non error status codes', function (done) {
+        it('does nothing for non error status codes', function () {
             var nextCalled = false;
             testMiddleware(req,res,function(){
                 nextCalled = true;
@@ -54,11 +53,10 @@ describe('errorMiddleware', function () {
             res.send(testMessage);
             assert(originalSendSpy.calledOnce,"Send should have been called once");
             expect(originalSendSpy.getCall(0).args[0],"sent message should not have been modified").to.equal(testMessage);
-            done();
         });
 
-        it('does nothing for error status codes without a catalolgedError', function (done) {
-            res.statusCode=400;
+        it('does nothing for error status codes without a catalogedError', function () {
+            res.statusCode = 400;
             var nextCalled = false;
             testMiddleware(req,res,function(){
                 nextCalled = true;
@@ -68,11 +66,10 @@ describe('errorMiddleware', function () {
             res.send(testMessage);
             assert(originalSendSpy.calledOnce,"Send should have been called once");
             expect(originalSendSpy.getCall(0).args[0],"sent message should not have been modified").to.equal(testMessage);
-            done();
         });
 
-        it('formats the message for error status codes', function (done) {
-            res.statusCode=400;
+        it('formats the message for error status codes', function () {
+            res.statusCode = 400;
             var nextCalled = false;
             testMiddleware(req,res,function(){
                 nextCalled = true;
@@ -85,11 +82,10 @@ describe('errorMiddleware', function () {
             expect(spyArg.message,"sent message should have a message property").to.exist;
             expect(spyArg.action,"sent message should have an action property").to.exist;
             expect(spyArg.detail,"sent message should have a detail property").to.exist;
-            done();
         });
 
-        it('passes the payload through when an error occurs', function (done) {
-            res.statusCode=400;
+        it('passes the payload through when an error occurs', function () {
+            res.statusCode = 400;
             var nextCalled = false;
             testMiddleware(req,res,function(){
                 nextCalled = true;
@@ -100,7 +96,6 @@ describe('errorMiddleware', function () {
             assert(originalSendSpy.calledOnce,"Send should have been called once");
             assert(originalSendSpy.calledOnce,"Send should have been called once");
             expect(originalSendSpy.getCall(0).args[0],"sent message should not have been modified").to.equal(testError);
-            done();
         });
     });
 });


### PR DESCRIPTION
Add optional pre-processing function to ErrorFormattingMiddleware

This can be used to alter or replace the message before formatting. For example it could replace message numbers, alter inserts such as changing casing or encoding etc.