### PR TITLE
Allow formatting preprocess function to be asynchronous

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,5 @@ node example/errorMiddlewareApp/errorMiddlewareApp.js
     }
     app.use(new ErrorFormattingMiddleware('catalog-index.json', myTransform));
     ```
+  The function can be synchronous (return a transformed message object) or asynchronous (return a promise to a
+  transformed message object)

--- a/example/errorMiddlewareApp/errorMiddlewareApp.js
+++ b/example/errorMiddlewareApp/errorMiddlewareApp.js
@@ -13,10 +13,35 @@ let app = express();
 let CatalogedError = require('../../index.js').catalogedError;
 let ErrorFormattingMiddleware = require('../../index.js').errorFormattingMiddleware;
 
-app.use(new ErrorFormattingMiddleware(__dirname + '/../../test/catalog-index.json'));
+const insertTransformer = (data) => {
+    return new Promise((resolve) => {
+        //Transform key inserts
+        for (var key in data.namedInserts) {
+            if (data.namedInserts.hasOwnProperty(key)) {
+                switch (typeof data.namedInserts[key]) {
+                    //Upper case strings
+                    case `string`:
+                        data.namedInserts[key] = data.namedInserts[key].toUpperCase();
+                        break;
+                    //Toggle booleans
+                    case `boolean`:
+                        data.namedInserts[key] = !data.namedInserts[key];
+                        break;
+                    //Double numbers
+                    case `number`:
+                        data.namedInserts[key] = data.namedInserts[key] * 2;
+                        break;
+                }
+            }
+        }
+        resolve(data);
+    });
+};
+
+app.use(new ErrorFormattingMiddleware(__dirname + '/../../test/catalog-index.json', insertTransformer));
 
 app.get('/*', function (req, res) {
-    let exampleError = new CatalogedError('0002','exampleLocal','Example error',{id:"EXAMPLE ID"},[]);
+    let exampleError = new CatalogedError('0002', 'exampleLocal', 'Example error', { id: "example id", number: 123, boolean: false }, []);
     res.status(400).send(exampleError);
 });
 

--- a/lib/middleware/errorMiddleware.js
+++ b/lib/middleware/errorMiddleware.js
@@ -1,4 +1,3 @@
-
 /*
  * Licensed Materials - Property of IBM
  * (C) Copyright IBM Corp. 2017, 2017. All Rights Reserved.
@@ -16,12 +15,13 @@ class CatalogedErrorFormatter {
      * Construct a middleware function to format instances of CatalogedMessage
      * @param {string} catalogIndex - path to message catalog file
      * @param {function} [preProcessorFunction] - optional function to transform a message before formatting it
+     *                                            the function can return either a {CatalogedError}, or a {Promise<CatalogedError>}
      * @returns {function} - Express-compatible middleware function
      */
     constructor(catalogIndex, preProcessorFunction) {
         var self = this;
         catalogManager = new MessageCatalogManager(catalogIndex);
-        return function(req,res,next) {
+        return function (req, res, next) {
             return self._middleware(req, res, next, preProcessorFunction);
         };
     }
@@ -33,17 +33,37 @@ class CatalogedErrorFormatter {
             try {
                 //If this has an error code and looks like a cataloged error then format it
                 if ((res.statusCode >= 400 && res.statusCode <= 599) &&
-                    data.messageNumber != undefined && data.catalog != undefined) {
+                    data.messageNumber !== undefined && data.catalog !== undefined) {
 
-                    if(preProcessorFunction){
-                        data = preProcessorFunction(data);
+                    // run pre-processor function if one was given
+                    if (preProcessorFunction) {
+                        var transformedData = preProcessorFunction(data);
+                        if (typeof transformedData.then === 'function') {
+                            // transformed data is then'able, treat as promise-to-data
+                            return transformedData
+                                .then(function (transformedData) {
+                                    var formattedData = catalogManager.getCatalogedErrorMessage(transformedData);
+                                    oldSend.call(this, formattedData);
+                                })
+                                .catch(function (){
+                                    // transformation has failed, send HTTP500 with unformatted original message
+                                    res.status(500);
+                                    oldSend.call(this, JSON.stringify(data));
+                                });
+                        }
+                        else {
+                            // transformed data is not a promise, use directly
+                            data = transformedData;
+                        }
                     }
+
                     //Format
                     data = catalogManager.getCatalogedErrorMessage(data);
                 }
             }
             catch (err) {
                 res.status(500);
+                data = JSON.stringify(data);
             }
             oldSend.call(this, data);
         };

--- a/lib/middleware/errorMiddleware.js
+++ b/lib/middleware/errorMiddleware.js
@@ -31,6 +31,7 @@ class CatalogedErrorFormatter {
 
         res.send = function (data) {
             try {
+                var _this=this;
                 //If this has an error code and looks like a cataloged error then format it
                 if ((res.statusCode >= 400 && res.statusCode <= 599) &&
                     data.messageNumber !== undefined && data.catalog !== undefined) {
@@ -43,12 +44,12 @@ class CatalogedErrorFormatter {
                             return transformedData
                                 .then(function (transformedData) {
                                     var formattedData = catalogManager.getCatalogedErrorMessage(transformedData);
-                                    oldSend.call(this, formattedData);
+                                    oldSend.call(_this, formattedData);
                                 })
-                                .catch(function (){
+                                .catch(function() {
                                     // transformation has failed, send HTTP500 with unformatted original message
                                     res.status(500);
-                                    oldSend.call(this, JSON.stringify(data));
+                                    oldSend.call(_this, JSON.stringify(data));
                                 });
                         }
                         else {

--- a/test/catalogs/example/messages.json
+++ b/test/catalogs/example/messages.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/IBM/message-catalog-manager/README.md"
   },
   "0002": {
-    "message": "This is an example message with a special insert {id} {number} {boolean}",
+    "message": "This is an example message with special inserts {id} - {number} - {boolean}",
     "action": "Write a real message",
     "detail": "detail detail detail {id}",
     "url": "https://github.com/IBM/message-catalog-manager/README.md"

--- a/test/errorMiddleware-test.js
+++ b/test/errorMiddleware-test.js
@@ -130,13 +130,13 @@ describe('errorMiddleware', function () {
             });
             testMiddleware(req,res,nextStub);
             expect(nextStub).to.have.callCount(1);
-            var testError = new CatalogedError('0002','exampleLocal','Example error',{id:"this-insert-gets-replaced"},[]);
+            var testError = new CatalogedError('0002','exampleLocal','Example error',{id:"this-insert-gets-replaced",number:1,boolean:true},[]);
             res.send(testError);
 
             expect(preProcessorStub).to.have.callCount(1);
             expect(originalSendSpy).to.have.callCount(1);
             var sentFormattedMessage = originalSendSpy.getCall(0).args[0];
-            expect(sentFormattedMessage.message).to.equal('This is an example message with a special insert transformed-sync {number} {boolean}');
+            expect(sentFormattedMessage.message).to.equal('This is an example message with special inserts transformed-sync - 1 - true');
         });
 
         it('sends HTTP500 unformatted original message when synchronous pre-processor throws', function (done) {
@@ -172,14 +172,14 @@ describe('errorMiddleware', function () {
             });
             testMiddleware(req,res,nextStub);
             expect(nextStub).to.have.callCount(1);
-            var testError = new CatalogedError('0002','exampleLocal','Example error',{id:"this-insert-gets-replaced"},[]);
+            var testError = new CatalogedError('0002','exampleLocal','Example error',{id:"this-insert-gets-replaced",number:1,boolean:true},[]);
 
             res.on('send', function(){
                 try {
                     expect(preProcessorStub).to.have.callCount(1);
                     expect(originalSendSpy).to.have.callCount(1);
                     var sentFormattedMessage = originalSendSpy.getCall(0).args[0];
-                    expect(sentFormattedMessage.message).to.equal('This is an example message with a special insert transformed-async {number} {boolean}');
+                    expect(sentFormattedMessage.message).to.equal('This is an example message with special inserts transformed-async - 1 - true');
                     done();
                 } catch (e) {
                     done(e);

--- a/test/message-catalog-manager-test.js
+++ b/test/message-catalog-manager-test.js
@@ -50,11 +50,11 @@ describe('MessageCatalogManager', function () {
         });
         it('returns a resolved message with special {id} insert in the default locale', function () {
             var message = MC.getMessage("exampleLocal", "0002", {id:"test-id", number: 0, boolean: true}, []);
-            expect(message.message).to.equal("This is an example message with a special insert test-id 0 true");
+            expect(message.message).to.equal("This is an example message with special inserts test-id - 0 - true");
         });
         it('returns a resolved message with special {id} insert in english locale', function () {
             var message = MC.getMessage("exampleLocal", "0002", {id:"test-id-en", number: 1, boolean: false}, [], "en");
-            expect(message.message).to.equal("This is an example message with a special insert test-id-en 1 false");
+            expect(message.message).to.equal("This is an example message with special inserts test-id-en - 1 - false");
         });
         it('returns a resolved message with special {id} insert in a different locale', function () {
             var message = MC.getMessage("exampleLocal", "0002", {id:"test-id-de"}, [], "de");
@@ -62,11 +62,11 @@ describe('MessageCatalogManager', function () {
         });
         it('returns a resolved message with special {id} insert in the default locale if the given one does not exist', function () {
             var message = MC.getMessage("exampleLocal", "0002", {id:"test-id-ro", number: 1, boolean: false}, [], "ro");
-            expect(message.message).to.equal("This is an example message with a special insert test-id-ro 1 false");
+            expect(message.message).to.equal("This is an example message with special inserts test-id-ro - 1 - false");
         });
         it('returns a resolved message with special {id} insert for non-string values', function () {
             var message = MC.getMessage("exampleLocal", "0002", {id: null, number: NaN, boolean: undefined}, []);
-            expect(message.message).to.equal("This is an example message with a special insert null NaN undefined");
+            expect(message.message).to.equal("This is an example message with special inserts null - NaN - undefined");
         });
         it('returns a resolved message with positional inserts in the default locale', function () {
             var message = MC.getMessage("exampleLocal", "0003", {}, ["one", 2, "three", true]);


### PR DESCRIPTION
This allows the `errorFormattingMiddleware()` optional parameter `preProcessorFunction` function, which is used to transform messages befre formatting them, to be asynchronous.
ie. it can return `Promise<message-object>` as an alternative to being synchronous returning `message-object` directly