### PR TITLE
Standardise api

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,28 +15,28 @@ For an example of the catalog file format see:
 For an example of the catalog index fileformat see:
 [catalog-index.json](test/catalogs/example/index.js)
 
-### Using messageCatalogManager
+### Using message-catalog-manager
 ```js
-var MessageCatalogManager = require("message-catalog").messageCatalogManager;
+var MessageCatalogManager = require("message-catalog-manager").MessageCatalogManager;
 var catalogManager = new MessageCatalogManager("/catalog-index.json");
 var formattedMessage = catalogManager.getMessage("catalog1", "0001", {}, ["myapp"]);
 ```
 
 ### Using catalogedError
 ```js
-var CatalogedError = require("message-catalog").catalogedError;
-var throw new CatalogedError("0001", "catalog1", "An error occurred", ["myapp"]);
+var CatalogedError = require("message-catalog").CatalogedError;
+throw new CatalogedError("0001", "catalog1", "An error occurred", ["myapp"]);
 ```
 
 ## Express Middleware
 
-If your Express application generates or receives a `catalogedError` you can use the `ErrorFormattingMiddleware` middleware to intercept all responses and attempt to format error responses before they are sent.
+If your Express application generates or receives a `CatalogedError` you can use the `formattingMiddleware` middleware to intercept all responses and attempt to format error responses before they are sent.
 
 ```js
 app.use(new ErrorFormattingMiddleware('catalog-index.json'));
 ```
 
-There is a simple application that always responds with a `catalogedError` in [example](/example). Start it like
+There is a simple application that always responds with a `CatalogedError` in [example](/example). Start it like
 ```
 node example/errorMiddlewareApp/errorMiddlewareApp.js
 ```
@@ -55,7 +55,7 @@ node example/errorMiddlewareApp/errorMiddlewareApp.js
 
 **v2.1.0**
 
-- Class `CatalogedError` is exported with a capitalised class name
+- Classes `MessageCatalogManager` and `CatalogedError` are exported with a capitalised class names
 - The message identifier for a `CatalogedError` instance renamed `messageCode` instead of `messageNumber` (it's type is string)
 - formattingMiddleware should be called as a function (not with `new`)
 - formattingMiddleware supports an optional function to transform messages before formatting:

--- a/README.md
+++ b/README.md
@@ -55,13 +55,15 @@ node example/errorMiddlewareApp/errorMiddlewareApp.js
 
 **v2.1.0**
 
-- ErrorFormattingMiddleware supports an optional function to transform messages before formatting:
+- Class `CatalogedError` is exported with a capitalised class name
+- formattingMiddleware should be called as a function (not with `new`)
+- formattingMiddleware supports an optional function to transform messages before formatting:
     ```js
     function myTransform(msg){
       // transform msg as required
       return msg;
     }
-    app.use(new ErrorFormattingMiddleware('catalog-index.json', myTransform));
+    app.use(messageCatalogManager.formattingMiddleware('catalog-index.json', myTransform));
     ```
   The function can be synchronous (return a transformed message object) or asynchronous (return a promise to a
   transformed message object)

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ node example/errorMiddlewareApp/errorMiddlewareApp.js
 **v2.1.0**
 
 - Class `CatalogedError` is exported with a capitalised class name
+- The message identifier for a `CatalogedError` instance renamed `messageCode` instead of `messageNumber` (it's type is string)
 - formattingMiddleware should be called as a function (not with `new`)
 - formattingMiddleware supports an optional function to transform messages before formatting:
     ```js

--- a/example/errorMiddlewareApp/errorMiddlewareApp.js
+++ b/example/errorMiddlewareApp/errorMiddlewareApp.js
@@ -10,25 +10,24 @@
 
 let express = require('express');
 let app = express();
-let CatalogedError = require('../../index.js').catalogedError;
-let ErrorFormattingMiddleware = require('../../index.js').errorFormattingMiddleware;
+let messageCatalogManager = require('../../index.js');
 
 const insertTransformer = (data) => {
     return new Promise((resolve) => {
         //Transform key inserts
-        for (var key in data.namedInserts) {
+        for (let key in data.namedInserts) {
             if (data.namedInserts.hasOwnProperty(key)) {
                 switch (typeof data.namedInserts[key]) {
                     //Upper case strings
-                    case `string`:
+                    case 'string':
                         data.namedInserts[key] = data.namedInserts[key].toUpperCase();
                         break;
                     //Toggle booleans
-                    case `boolean`:
+                    case 'boolean':
                         data.namedInserts[key] = !data.namedInserts[key];
                         break;
                     //Double numbers
-                    case `number`:
+                    case 'number':
                         data.namedInserts[key] = data.namedInserts[key] * 2;
                         break;
                 }
@@ -38,10 +37,10 @@ const insertTransformer = (data) => {
     });
 };
 
-app.use(new ErrorFormattingMiddleware(__dirname + '/../../test/catalog-index.json', insertTransformer));
+app.use(messageCatalogManager.formattingMiddleware(__dirname + '/../../test/catalog-index.json', insertTransformer));
 
 app.get('/*', function (req, res) {
-    let exampleError = new CatalogedError('0002', 'exampleLocal', 'Example error', { id: "example id", number: 123, boolean: false }, []);
+    let exampleError = new messageCatalogManager.CatalogedError('0002', 'exampleLocal', 'Example error', { id: "example id", number: 123, boolean: false }, []);
     res.status(400).send(exampleError);
 });
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@
 'use strict';
 
 module.exports = {
-    messageCatalogManager: require('./lib/message-catalog-manager').MessageCatalogManager,
+    MessageCatalogManager: require('./lib/message-catalog-manager').MessageCatalogManager,
     CatalogedError: require('./lib/catalogedError.js'),
     formattingMiddleware: require('./lib/middleware/errorMiddleware.js'),
 };

--- a/index.js
+++ b/index.js
@@ -7,6 +7,6 @@
 
 module.exports = {
     messageCatalogManager: require('./lib/message-catalog-manager').MessageCatalogManager,
-    catalogedError: require('./lib/catalogedError.js'),
-    errorFormattingMiddleware: require('./lib/middleware/errorMiddleware.js'),
+    CatalogedError: require('./lib/catalogedError.js'),
+    formattingMiddleware: require('./lib/middleware/errorMiddleware.js'),
 };

--- a/lib/catalogedError.js
+++ b/lib/catalogedError.js
@@ -12,22 +12,31 @@ class CatalogedError extends Error {
 
     /**
      * Construct a catalogedError
-     * @param {string}   messageNumber - message code
+     * @param {string}   messageCode - message's identifier in the catalog
      * @param {string}   catalog - catalog containing message
      * @param {string}   message - debug message text
      * @param {[object<string,*>]} namedInserts - optional map of named message inserts
      * @param {[*[]]}    positionalInserts - optional array of positional message inserts
      */
-    constructor(messageNumber, catalog, message, namedInserts, positionalInserts) {
+    constructor(messageCode, catalog, message, namedInserts, positionalInserts) {
 
         messageCatalogManager.internal.validateNamedInsertTypes(namedInserts);
         messageCatalogManager.internal.validatePositionalInsertTypes(positionalInserts);
 
         super(message);
-        this.messageNumber = messageNumber || "DEFAULT";
+        this.messageCode = messageCode || "DEFAULT";
         this.catalog = catalog || "DEFAULT";
         this.namedInserts = namedInserts || {};
         this.positionalInserts = positionalInserts || [];
+    }
+
+    /**
+     * @deprecated For pre v2.1 compatibility only
+     *             Please use `messageCode` instead to get the message's unique identifier
+     * @returns {string} - message code
+     */
+    get messageNumber() {
+        return this.messageCode;
     }
 }
 

--- a/lib/catalogedError.js
+++ b/lib/catalogedError.js
@@ -8,7 +8,7 @@
 
 var messageCatalogManager = require("./message-catalog-manager.js");
 
-class catalogedError extends Error {
+class CatalogedError extends Error {
 
     /**
      * Construct a catalogedError
@@ -31,4 +31,4 @@ class catalogedError extends Error {
     }
 }
 
-module.exports = catalogedError;
+module.exports = CatalogedError;

--- a/lib/message-catalog-manager.js
+++ b/lib/message-catalog-manager.js
@@ -205,7 +205,13 @@ MessageCatalogManager.prototype.getCatalogedErrorMessage = function (catalogedEr
         //Tolerate V0 style catalogedError
         catalogedError.positionalInserts = catalogedError.inserts;
     }
-    var msg = this.getMessage(catalogedError.catalog,catalogedError.messageCode,catalogedError.namedInserts,catalogedError.positionalInserts);
+    let messageCode = catalogedError.messageCode;
+    if (catalogedError.messageNumber !== undefined){
+        // support 'messageNumber' as the code for backward compatibility
+        // this could be a plain JSON serialisation of a pre v2.1 message, where the getter is not available
+        messageCode = catalogedError.messageNumber;
+    }
+    let msg = this.getMessage(catalogedError.catalog,messageCode,catalogedError.namedInserts,catalogedError.positionalInserts);
 
     return msg;
 };

--- a/lib/message-catalog-manager.js
+++ b/lib/message-catalog-manager.js
@@ -205,7 +205,7 @@ MessageCatalogManager.prototype.getCatalogedErrorMessage = function (catalogedEr
         //Tolerate V0 style catalogedError
         catalogedError.positionalInserts = catalogedError.inserts;
     }
-    var msg = this.getMessage(catalogedError.catalog,catalogedError.messageNumber,catalogedError.namedInserts,catalogedError.positionalInserts);
+    var msg = this.getMessage(catalogedError.catalog,catalogedError.messageCode,catalogedError.namedInserts,catalogedError.positionalInserts);
 
     return msg;
 };

--- a/lib/middleware/errorMiddleware.js
+++ b/lib/middleware/errorMiddleware.js
@@ -26,7 +26,8 @@ function formattingMiddleware (catalogIndex, preProcessorFunction){
                 let _this=this;
                 //If this has an error code and looks like a cataloged error then format it
                 if ((res.statusCode >= 400 && res.statusCode <= 599) &&
-                    data.messageNumber !== undefined && data.catalog !== undefined) {
+                    (data.messageNumber !== undefined || data.messageCode !== undefined) && // support JSON serialised pre v2.1, which has a `messageNumber` instead of `messageCode`
+                    data.catalog !== undefined) {
 
                     // run pre-processor function if one was given
                     if (preProcessorFunction) {

--- a/lib/middleware/errorMiddleware.js
+++ b/lib/middleware/errorMiddleware.js
@@ -7,43 +7,35 @@
 
 'use strict';
 let MessageCatalogManager = require('../message-catalog-manager.js').MessageCatalogManager;
-let catalogManager;
 
-class CatalogedErrorFormatter {
+/**
+ * Construct a middleware function to format instances of CatalogedError
+ * @param {string} catalogIndex - path to message catalog file
+ * @param {function} [preProcessorFunction] - optional function to transform a message before formatting it
+ *                                            the function can return either a {CatalogedError}, or a {Promise<CatalogedError>}
+ * @returns {function} - Express-compatible middleware function
+ */
+function formattingMiddleware (catalogIndex, preProcessorFunction){
+    let catalogManager = new MessageCatalogManager(catalogIndex);
 
-    /**
-     * Construct a middleware function to format instances of CatalogedMessage
-     * @param {string} catalogIndex - path to message catalog file
-     * @param {function} [preProcessorFunction] - optional function to transform a message before formatting it
-     *                                            the function can return either a {CatalogedError}, or a {Promise<CatalogedError>}
-     * @returns {function} - Express-compatible middleware function
-     */
-    constructor(catalogIndex, preProcessorFunction) {
-        var self = this;
-        catalogManager = new MessageCatalogManager(catalogIndex);
-        return function (req, res, next) {
-            return self._middleware(req, res, next, preProcessorFunction);
-        };
-    }
-
-    _middleware(req, res, next, preProcessorFunction) {
-        var oldSend = res.send;
+    return function (req, res, next) {
+        let oldSend = res.send;
 
         res.send = function (data) {
             try {
-                var _this=this;
+                let _this=this;
                 //If this has an error code and looks like a cataloged error then format it
                 if ((res.statusCode >= 400 && res.statusCode <= 599) &&
                     data.messageNumber !== undefined && data.catalog !== undefined) {
 
                     // run pre-processor function if one was given
                     if (preProcessorFunction) {
-                        var transformedData = preProcessorFunction(data);
+                        let transformedData = preProcessorFunction(data);
                         if (typeof transformedData.then === 'function') {
                             // transformed data is then'able, treat as promise-to-data
                             return transformedData
                                 .then(function (transformedData) {
-                                    var formattedData = catalogManager.getCatalogedErrorMessage(transformedData);
+                                    let formattedData = catalogManager.getCatalogedErrorMessage(transformedData);
                                     oldSend.call(_this, formattedData);
                                 })
                                 .catch(function() {
@@ -69,7 +61,7 @@ class CatalogedErrorFormatter {
             oldSend.call(this, data);
         };
         next();
-    }
+    };
 }
 
-module.exports = CatalogedErrorFormatter;
+module.exports = formattingMiddleware;

--- a/test/cataloged-error-test.js
+++ b/test/cataloged-error-test.js
@@ -26,7 +26,7 @@ describe('catalogedError testcases', function () {
             expect(err).to.be.an.instanceof(Error);
             expect(err).to.be.an.instanceof(CatalogedError);
             assert.isArray(err.positionalInserts,"positionalInserts should be an array");
-            assert.isDefined(err.messageNumber,"messageNumber should be defined");
+            assert.isDefined(err.messageCode,"messageCode should be defined");
             assert.isObject(err.namedInserts,"namedInserts should be defined");
             expect(err.messageNumber).to.equal("1");
             expect(err.message).to.equal(messageText);
@@ -45,8 +45,8 @@ describe('catalogedError testcases', function () {
             expect(err).to.be.an.instanceof(CatalogedError);
             assert.isArray(err.positionalInserts,"positionalInserts should be an array");
             assert.isObject(err.namedInserts,"namedInserts should be an object");
-            assert.isDefined(err.messageNumber,"messageNumber should be defined");
-            expect(err.messageNumber).to.equal("DEFAULT");
+            assert.isDefined(err.messageCode,"messageCode should be defined");
+            expect(err.messageCode).to.equal("DEFAULT");
             expect(err.message).to.equal(messageText);
             expect(err.catalog).to.equal("DEFAULT");
             done();
@@ -95,5 +95,18 @@ describe('catalogedError testcases', function () {
             new CatalogedError("1", catalog, messageText, messageNamedInserts, messagePositionalInserts);
         }
         expect(createBadCatalogedError).throws("positionalInserts value with index: '1' is of unsupported type function");
+    });
+
+    it('has deprecated messageNumber for messageCode', function (done) {
+        var messageText = "Test Error";
+        var catalog = "my-cat";
+        try {
+            throw new CatalogedError("theMessageCode001",catalog,messageText,[], undefined);
+        }
+        catch (err){
+            expect(err.messageCode).to.equal("theMessageCode001");
+            expect(err.messageNumber).to.equal("theMessageCode001");
+            done();
+        }
     });
 });

--- a/test/errorMiddleware-test.js
+++ b/test/errorMiddleware-test.js
@@ -14,10 +14,10 @@ chai.use(sinonChai);
 var sinon = require('sinon');
 var httpMocks = require('node-mocks-http');
 var events = require('events');
-var Middleware = require('../lib/middleware/errorMiddleware.js');
+var formattingMiddleware = require('../lib/middleware/errorMiddleware.js');
 var CatalogedError = require('../lib/catalogedError.js');
 
-describe('errorMiddleware', function () {
+describe('formattingMiddleware', function () {
 
     var testMiddleware;
     var req;
@@ -38,20 +38,20 @@ describe('errorMiddleware', function () {
     });
 
     it('can be constructed with a catalog index', function () {
-        var testMiddleware = new Middleware(__dirname + '/catalog-index.json');
+        var testMiddleware = formattingMiddleware(__dirname + '/catalog-index.json');
         assert.isFunction(testMiddleware);
     });
 
     it('can be constructed with an optional pre-processor', function() {
         function myPreProcessorFunction() {}
-        var testMiddleware = new Middleware(__dirname + '/catalog-index.json', myPreProcessorFunction);
+        var testMiddleware = formattingMiddleware(__dirname + '/catalog-index.json', myPreProcessorFunction);
         assert.isFunction(testMiddleware);
     });
 
     describe('function without pre-processor', function () {
 
         beforeEach(function () {
-            testMiddleware = new Middleware(__dirname + '/catalog-index.json');
+            testMiddleware = formattingMiddleware(__dirname + '/catalog-index.json');
         });
 
         it('does nothing for non error status codes', function () {
@@ -116,7 +116,7 @@ describe('errorMiddleware', function () {
         beforeEach(function () {
             preProcessorStub = sinon.stub();
             nextStub = sinon.stub();
-            testMiddleware = new Middleware(__dirname + '/catalog-index.json', preProcessorStub);
+            testMiddleware = formattingMiddleware(__dirname + '/catalog-index.json', preProcessorStub);
             res.statusCode = 400;
         });
 

--- a/test/errorMiddleware-test.js
+++ b/test/errorMiddleware-test.js
@@ -105,7 +105,6 @@ describe('formattingMiddleware', function () {
             var testError = new CatalogedError('missing-error-code-causes-failure','error','Example error',{id:"EXAMPLE ID"},[]);
             res.send(testError);
             assert(originalSendSpy.calledOnce,"Send should have been called once");
-            assert(originalSendSpy.calledOnce,"Send should have been called once");
             expect(originalSendSpy.getCall(0).args[0],"sent message should not have been modified").to.equal(JSON.stringify(testError));
         });
     });

--- a/test/message-catalog-manager-test.js
+++ b/test/message-catalog-manager-test.js
@@ -11,7 +11,7 @@ var expect = chai.expect;
 chai.use(chaiAsPromised);
 var sinonChai = require("sinon-chai");
 chai.use(sinonChai);
-var MessageCatalogManager = require("../index.js").messageCatalogManager;
+var MessageCatalogManager = require("../index.js").MessageCatalogManager;
 var CatalogedError = require('../lib/catalogedError.js');
 var messageCatLib = require("../lib/message-catalog-manager.js");
 


### PR DESCRIPTION
Make API clearer and more standardised:

- the express formatting middleware is exported as `formattingMiddleware` and called as a function, not a constructor (no `new`)
- the `CatalogedError` class is exported with a capitalised name, it should be called as a constructor (with `new`)
-  a `CatalogedError` instance's unique identifier is renamed from `messageNumber` to `messageCode`, since it does not have to be a number, it's type is string.
  a deprecated getter is added for `messageNumber` for backward compatibility