### PR TITLE
support windows file paths containing backslashes

### DIFF
--- a/lib/message-catalog-manager.js
+++ b/lib/message-catalog-manager.js
@@ -9,6 +9,7 @@
 var fileUrlRe = /^file:\/\//gi;
 var remoteUrlRe = /^http:\/\//gi;
 var _ = require('underscore');
+var path = require('path');
 
 //Message-Catalog-Manager class
 var MessageCatalogManager = function (indexFilePath) {
@@ -16,7 +17,7 @@ var MessageCatalogManager = function (indexFilePath) {
 
     //Load the catalog-index object
     this.catalogIndex = require(this.indexFilePath);
-    this.catalogRootPath = this.indexFilePath.substring(0, this.indexFilePath.lastIndexOf("/"));
+    this.catalogRootPath = path.dirname(this.indexFilePath);
 
 
     //Cache valid, local catalog files
@@ -27,8 +28,8 @@ var MessageCatalogManager = function (indexFilePath) {
         if (this.catalogIndex.hasOwnProperty(catalogName)) {
             var catalogIndexEntry = this.catalogIndex[catalogName];
             if (String(catalogIndexEntry.url).match(fileUrlRe)) {
-                var filePath = catalogIndexEntry.url.substring(8);
-                var catalogPath = this.catalogRootPath + filePath.substring(0, filePath.lastIndexOf("/") + 1);
+                var filePath = path.dirname(catalogIndexEntry.url.substring(8));
+                var catalogPath = path.join(this.catalogRootPath, filePath);
 
                 //Load all catalogs in cache
                 var catalogs = require(catalogPath);


### PR DESCRIPTION
Fixes #11

Use library `path` for processing filenames and paths, which deals with forwardslash/backslash conversion on Windows