### PR TITLE
Add support to select named inserts for output message object

### DIFF
--- a/lib/message-catalog-manager.js
+++ b/lib/message-catalog-manager.js
@@ -192,6 +192,20 @@ MessageCatalogManager.prototype.getMessage = function (catalogName, code, namedI
         message.detail = applyInserts(message.detail, namedInserts, positionalInserts);
     }
 
+    // If dataNamedInsertsPattern is supplied, use this regular expression to select named inserts to put in the output message object
+    if (message.dataNamedInsertsPattern) {
+        const regex = new RegExp(message.dataNamedInsertsPattern);
+        const filteredNamedInserts = Object.keys(message.namedInserts)
+            .filter(key => key.match(regex))
+            .reduce((newObject, key) => {
+                newObject[key] = message.namedInserts[key];
+                return newObject;
+            }, {});
+        if(Object.keys(filteredNamedInserts).length !== 0) {
+            message.data = filteredNamedInserts;
+        }
+    }
+
     if(!verbose) {
         delete message.namedInserts;
     }

--- a/test/catalogs/example/messages.json
+++ b/test/catalogs/example/messages.json
@@ -34,7 +34,7 @@
     }
   },
   "0008": {
-    "message": "This is a message with additional inserts",
+    "message": "This is a message with a pattern to select named inserts",
     "action": "Write a real message",
     "url": "https://github.com/IBM/message-catalog-manager/README.md",
     "dataNamedInsertsPattern": "^(user\\.)"

--- a/test/catalogs/example/messages.json
+++ b/test/catalogs/example/messages.json
@@ -32,5 +32,11 @@
     "namedInserts": {
       "key": "value"
     }
+  },
+  "0008": {
+    "message": "This is a message with additional inserts",
+    "action": "Write a real message",
+    "url": "https://github.com/IBM/message-catalog-manager/README.md",
+    "dataNamedInsertsPattern": "^(user\\.)"
   }
 }

--- a/test/message-catalog-manager-test.js
+++ b/test/message-catalog-manager-test.js
@@ -139,7 +139,15 @@ describe('MessageCatalogManager', function () {
             expect(message.namedInserts).to.deep.equal({foo:"bar"});
         });
 
+        it('returns filtered inserts list when message.dataNamedInsertsPattern exists and matches', function () {
+            var message =  MC.getMessage("exampleLocal", "0008", {"user.key": "userValue","otherKey": "otherValue"},[],"en", 1);
+            expect(message.data).to.deep.equal({"user.key":"userValue"});
+        });
 
+        it('returns message without filtered inserts list when message.dataNamedInsertsPattern does not match anything', function () {
+            var message =  MC.getMessage("exampleLocal", "0008", {"otherKey": "otherValue"},[],"en", 1);
+            expect(message.data).to.equal(undefined);
+        });
     });
 
     describe('checkCatalog', function () {


### PR DESCRIPTION
This pull request enhances the `getMessage` function to allow a `dataNamedInsertsPattern` value (which is a regular expression) to be supplied in the incoming message object which is used to select `namedInserts` keys to be built into the output message object under `data`.

For example, if you have `message.namedInserts` with
```
{
  "user.key": "userValue",
  "otherKey": "otherValue"
}
```
and supply a `dataNamedInsertsPattern` value of `^(user\\.)` then you would get
```
{
  "user.key": "userValue"
}
```
in `message.data`.

This allows a user to selectively include some of the `namedInserts` values in the output, separate from including the whole `namedInserts` block depending on whether `verbose` is set to `true` or `false`