### PR TITLE
Test against newer versions of node.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
+- '10'
+- '8'
 - '6'
-- '5'
 - '4.4'
 after_success:
 - npm run coveralls


### PR DESCRIPTION
Currently this project runs Travis against node.js 4.4, 5, and 6. Version 8 is the current LTS, and version 10 is the latest (and next LTS from October), so it would be good to test this project against those too. Version 5 can also be dropped as that has not been supported in quite a while (it was never an LTS).

Arguably version 4 could be dropped too as it is no longer supported, but that's the minimum on this library at the moment and may have an impact on consumers, so I am suggesting leaving it for now.