### PR TITLE
Add static method to determine if object is cataloged error

### DIFF
--- a/lib/catalogedError.js
+++ b/lib/catalogedError.js
@@ -39,6 +39,11 @@ class CatalogedError extends Error {
         return this.messageCode;
     }
 
+    /**
+     * Returns true if an object is a cataloged error
+     * @param {Object} object - object to check
+     * @returns {boolean} - is a cataloged error
+     */
     static isCatalogedError (object) {
         return (
             (object instanceof Object) &&

--- a/lib/catalogedError.js
+++ b/lib/catalogedError.js
@@ -38,6 +38,14 @@ class CatalogedError extends Error {
     get messageNumber() {
         return this.messageCode;
     }
+
+    static isCatalogedError (object) {
+        return (
+            (object instanceof Object) &&
+            (object.messageNumber !== undefined || object.messageCode !== undefined) && // support JSON serialised pre v2.1, which has a `messageNumber` instead of `messageCode`
+            (object.catalog !== undefined)
+        );
+    }
 }
 
 module.exports = CatalogedError;

--- a/lib/middleware/errorMiddleware.js
+++ b/lib/middleware/errorMiddleware.js
@@ -7,6 +7,7 @@
 
 'use strict';
 let MessageCatalogManager = require('../message-catalog-manager.js').MessageCatalogManager;
+const CatalogedError = require('../catalogedError.js');
 
 /**
  * Construct a middleware function to format instances of CatalogedError
@@ -25,9 +26,7 @@ function formattingMiddleware (catalogIndex, preProcessorFunction){
             try {
                 let _this=this;
                 //If this has an error code and looks like a cataloged error then format it
-                if ((res.statusCode >= 400 && res.statusCode <= 599) &&
-                    (data.messageNumber !== undefined || data.messageCode !== undefined) && // support JSON serialised pre v2.1, which has a `messageNumber` instead of `messageCode`
-                    data.catalog !== undefined) {
+                if (res.statusCode >= 400 && res.statusCode <= 599 && CatalogedError.isCatalogedError(data)) {
 
                     // run pre-processor function if one was given
                     if (preProcessorFunction) {

--- a/test/cataloged-error-test.js
+++ b/test/cataloged-error-test.js
@@ -109,4 +109,20 @@ describe('catalogedError testcases', function () {
             done();
         }
     });
+
+    describe('isCatalogedError', function () {
+        it('returns false if object is not a cataloged error', function () {
+            expect(CatalogedError.isCatalogedError()).to.equal(false);
+            expect(CatalogedError.isCatalogedError(null)).to.equal(false);
+            expect(CatalogedError.isCatalogedError(123)).to.equal(false);
+            expect(CatalogedError.isCatalogedError('string')).to.equal(false);
+            expect(CatalogedError.isCatalogedError({})).to.equal(false);
+            expect(CatalogedError.isCatalogedError(function () {})).to.equal(false);
+        });
+
+        it('returns true if object is a cataloged error', function () {
+            var catalogedError = new CatalogedError('0001', 'exampleLocal', 'Test Error');
+            expect(CatalogedError.isCatalogedError(catalogedError)).to.equal(true);
+        });
+    });
 });


### PR DESCRIPTION
Add static method to determine if object is cataloged error.
This can then be used by the middleware, and also by consumers.
