### PR TITLE
Removing stack

### DIFF
--- a/lib/middleware/errorMiddleware.js
+++ b/lib/middleware/errorMiddleware.js
@@ -41,6 +41,7 @@ function formattingMiddleware (catalogIndex, preProcessorFunction){
                                 .catch(function() {
                                     // transformation has failed, send HTTP500 with unformatted original message
                                     res.status(500);
+                                    delete data.stack;
                                     oldSend.call(_this, JSON.stringify(data));
                                 });
                         }
@@ -56,6 +57,7 @@ function formattingMiddleware (catalogIndex, preProcessorFunction){
             }
             catch (err) {
                 res.status(500);
+                delete data.stack;
                 data = JSON.stringify(data);
             }
             oldSend.call(this, data);


### PR DESCRIPTION
In the case that `JSON.stringify` does not delete the stack when It does not process the object methods. It can cause the problem that stack can return the unformatted error.

I believe we always need to delete the stack to the endpoint user. 

