### PR TITLE
Remove engines from package.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+- '14'
 - '10'
 - '8'
 - '6'

--- a/package.json
+++ b/package.json
@@ -2,10 +2,6 @@
   "name": "message-catalog-manager",
   "version": "2.2.2",
   "description": "message catalog manager",
-  "engines": {
-    "node": "4.4",
-    "npm": "3.x"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/IBM/message-catalog-manager"

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "message-catalog-manager",
   "version": "2.2.2",
   "description": "message catalog manager",
+  "engines": {
+    "node": ">=4.4",
+    "npm": ">=3.x"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/IBM/message-catalog-manager"


### PR DESCRIPTION
When we try do npm install on our projects with node 14
```
npm WARN notsup Unsupported engine for @ibm-app-connect/loopback-connector-provider-library@1.0.200: wanted: {"node":"10","npm":"6"} (current: {"node":"14.15.1","npm":"6.14.8"})
npm WARN notsup Not compatible with your version of node/npm: @ibm-app-connect/loopback-connector-provider-library@1.0.200
```

We are hitting this warning. engines will be mentioned at the application level, hence removing engines from this library.!