### PR TITLE
Bump Node.js versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 node_js:
-- '10'
-- '8'
-- '6'
-- '4.4'
+- 14
+- 16
+- 18
 after_success:
 - npm run coveralls
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "message-catalog-manager",
-  "version": "2.2.2",
+  "version": "3.0.0",
   "description": "message catalog manager",
   "engines": {
     "node": ">=14",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "2.2.2",
   "description": "message catalog manager",
   "engines": {
-    "node": "4.4",
-    "npm": "3.x"
+    "node": ">=14",
+    "npm": ">=6"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bump the version of Node.js that Travis runs against to supported versions, and also bump the `engines` section to the new minimum version (to avoid all the current installation warnings, as it claims 4.4-only). As this removes versions from support, bump the major version to `3.0.0`