### PR TITLE
Fix Travis build break by requiring Ubuntu Focal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: focal
 language: node_js
 node_js:
 - 14


### PR DESCRIPTION
The adoption of new Node.js versions in the previous commit broke Travis as the default Ubuntu level has too old a level of `gcc` for Node.js 18. This PR forces the use of Ubuntu Focal (20.04) which does have the right support (and you can see Travis working in this PR)