### PR TITLE
Remove fs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "coveralls": "npm run cover -- --report lcovonly && cat ./coverage/lcov.info | coveralls"
   },
   "dependencies": {
-    "fs": "0.0.2",
     "underscore": "^1.8.3"
   },
   "license": "MIT",


### PR DESCRIPTION
Fixes https://github.com/IBM/message-catalog-manager/issues/29

It doesn't appear that `fs` is actually being used, so we should remove it - an old, fixed, version - from `package.json`