### PR TITLE
Add language support for getCatalogedErrorMessage

### DIFF
--- a/lib/message-catalog-manager.js
+++ b/lib/message-catalog-manager.js
@@ -236,7 +236,7 @@ MessageCatalogManager.prototype.getMessage = function (catalogName, code, namedI
 
 };
 
-MessageCatalogManager.prototype.getCatalogedErrorMessage = function (catalogedError) {
+MessageCatalogManager.prototype.getCatalogedErrorMessage = function (catalogedError, language) {
     if (catalogedError.inserts !== undefined && catalogedError.positionalInserts === undefined)
     {
         //Tolerate V0 style catalogedError
@@ -248,7 +248,7 @@ MessageCatalogManager.prototype.getCatalogedErrorMessage = function (catalogedEr
         // this could be a plain JSON serialisation of a pre v2.1 message, where the getter is not available
         messageCode = catalogedError.messageNumber;
     }
-    let msg = this.getMessage(catalogedError.catalog,messageCode,catalogedError.namedInserts,catalogedError.positionalInserts);
+    let msg = this.getMessage(catalogedError.catalog,messageCode,catalogedError.namedInserts,catalogedError.positionalInserts,language);
 
     return msg;
 };

--- a/lib/middleware/errorMiddleware.js
+++ b/lib/middleware/errorMiddleware.js
@@ -14,9 +14,10 @@ const CatalogedError = require('../catalogedError.js');
  * @param {string} catalogIndex - path to message catalog file
  * @param {function} [preProcessorFunction] - optional function to transform a message before formatting it
  *                                            the function can return either a {CatalogedError}, or a {Promise<CatalogedError>}
+ * @param {string} [language] - optional language code (e.g., 'en', 'es', 'fr'). If not provided, will default to 'en'
  * @returns {function} - Express-compatible middleware function
  */
-function formattingMiddleware (catalogIndex, preProcessorFunction){
+function formattingMiddleware (catalogIndex, preProcessorFunction, language){
     let catalogManager = new MessageCatalogManager(catalogIndex);
 
     return function (req, res, next) {
@@ -35,7 +36,7 @@ function formattingMiddleware (catalogIndex, preProcessorFunction){
                             // transformed data is then'able, treat as promise-to-data
                             return transformedData
                                 .then(function (transformedData) {
-                                    let formattedData = catalogManager.getCatalogedErrorMessage(transformedData);
+                                    let formattedData = catalogManager.getCatalogedErrorMessage(transformedData, language);
                                     oldSend.call(_this, formattedData);
                                 })
                                 .catch(function() {
@@ -51,8 +52,8 @@ function formattingMiddleware (catalogIndex, preProcessorFunction){
                         }
                     }
 
-                    //Format
-                    data = catalogManager.getCatalogedErrorMessage(data);
+                    //Format with language support
+                    data = catalogManager.getCatalogedErrorMessage(data, language);
                 }
             }
             catch (err) {

--- a/test/catalogs/example/messages-fr.json
+++ b/test/catalogs/example/messages-fr.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/IBM/message-catalog-manager/README.md"
   },
   "0002": {
-    "message": "This is an example message with a special insert {id}, in french locale",
+    "message": "This is an example message with special inserts {id} - {number} - {boolean}, in french locale",
     "action": "Write a real message",
     "url": "https://github.com/IBM/message-catalog-manager/README.md"
   },

--- a/test/errorMiddleware-test.js
+++ b/test/errorMiddleware-test.js
@@ -285,4 +285,112 @@ describe('formattingMiddleware', function () {
 
 
     });
+
+    describe('function with language parameter', function () {
+        beforeEach(function () {
+            res.statusCode = 400;
+        });
+
+        it('formats message in English when language is "en"', function () {
+            testMiddleware = formattingMiddleware(__dirname + '/catalog-index.json', null, 'en');
+            var nextCalled = false;
+            testMiddleware(req, res, function () {
+                nextCalled = true;
+            });
+            assert.isTrue(nextCalled);
+            var testError = new CatalogedError('0001', 'exampleLocal', 'Example error', {}, []);
+            res.send(testError);
+            assert(originalSendSpy.calledOnce, "Send should have been called once");
+            var spyArg = originalSendSpy.getCall(0).args[0];
+            expect(spyArg.message).to.equal('This is an example message');
+        });
+
+        it('formats message in French when language is "fr"', function () {
+            testMiddleware = formattingMiddleware(__dirname + '/catalog-index.json', null, 'fr');
+            var nextCalled = false;
+            testMiddleware(req, res, function () {
+                nextCalled = true;
+            });
+            assert.isTrue(nextCalled);
+            var testError = new CatalogedError('0001', 'exampleLocal', 'Example error', {}, []);
+            res.send(testError);
+            assert(originalSendSpy.calledOnce, "Send should have been called once");
+            var spyArg = originalSendSpy.getCall(0).args[0];
+            expect(spyArg.message).to.equal('This is an example message for french catalog');
+        });
+
+        it('formats message in German when language is "de"', function () {
+            testMiddleware = formattingMiddleware(__dirname + '/catalog-index.json', null, 'de');
+            var nextCalled = false;
+            testMiddleware(req, res, function () {
+                nextCalled = true;
+            });
+            assert.isTrue(nextCalled);
+            var testError = new CatalogedError('0002', 'exampleLocal', 'Example error', {id: 'test-id'}, []);
+            res.send(testError);
+            assert(originalSendSpy.calledOnce, "Send should have been called once");
+            var spyArg = originalSendSpy.getCall(0).args[0];
+            expect(spyArg.message).to.equal('This is an example message with a special insert test-id, in german locale');
+        });
+
+        it('formats message in Japanese when language is "jp"', function () {
+            testMiddleware = formattingMiddleware(__dirname + '/catalog-index.json', null, 'jp');
+            var nextCalled = false;
+            testMiddleware(req, res, function () {
+                nextCalled = true;
+            });
+            assert.isTrue(nextCalled);
+            var testError = new CatalogedError('0001', 'exampleLocal', 'Example error', {}, []);
+            res.send(testError);
+            assert(originalSendSpy.calledOnce, "Send should have been called once");
+            var spyArg = originalSendSpy.getCall(0).args[0];
+            expect(spyArg.message).to.equal('This is an example message for japanese catalog');
+        });
+
+        it('falls back to English when language is not available', function () {
+            testMiddleware = formattingMiddleware(__dirname + '/catalog-index.json', null, 'es');
+            var nextCalled = false;
+            testMiddleware(req, res, function () {
+                nextCalled = true;
+            });
+            assert.isTrue(nextCalled);
+            var testError = new CatalogedError('0001', 'exampleLocal', 'Example error', {}, []);
+            res.send(testError);
+            assert(originalSendSpy.calledOnce, "Send should have been called once");
+            var spyArg = originalSendSpy.getCall(0).args[0];
+            expect(spyArg.message).to.equal('This is an example message');
+        });
+
+        it('falls back to English for message not in specified language', function () {
+            testMiddleware = formattingMiddleware(__dirname + '/catalog-index.json', null, 'de');
+            var nextCalled = false;
+            testMiddleware(req, res, function () {
+                nextCalled = true;
+            });
+            assert.isTrue(nextCalled);
+            var testError = new CatalogedError('0004', 'exampleLocal', 'Example error', {}, []);
+            res.send(testError);
+            assert(originalSendSpy.calledOnce, "Send should have been called once");
+            var spyArg = originalSendSpy.getCall(0).args[0];
+            expect(spyArg.message).to.equal('This is a message only in the default catalog');
+        });
+
+        it('works with pre-processor and language parameter', function () {
+            var preProcessorStub = sinon.stub().callsFake(function (msg) {
+                var newMsg = JSON.parse(JSON.stringify(msg));
+                newMsg.namedInserts.id = 'transformed-with-lang';
+                return newMsg;
+            });
+            testMiddleware = formattingMiddleware(__dirname + '/catalog-index.json', preProcessorStub, 'de');
+            var nextStub = sinon.stub();
+            testMiddleware(req, res, nextStub);
+            expect(nextStub).to.have.callCount(1);
+            var testError = new CatalogedError('0002', 'exampleLocal', 'Example error', {id: 'original-id'}, []);
+            res.send(testError);
+            expect(preProcessorStub).to.have.callCount(1);
+            expect(originalSendSpy).to.have.callCount(1);
+            var sentFormattedMessage = originalSendSpy.getCall(0).args[0];
+            expect(sentFormattedMessage.message).to.equal('This is an example message with a special insert transformed-with-lang, in german locale');
+        });
+    });
 });

--- a/test/message-catalog-manager-test.js
+++ b/test/message-catalog-manager-test.js
@@ -202,6 +202,56 @@ describe('MessageCatalogManager', function () {
             var message = MC.getCatalogedErrorMessage(catalogedError);
             expect(message.message).to.equal("This is an example message with positional inserts 1 2 3 4");
         });
+        it('returns a message in English when language is "en"', function() {
+            var messageText = "Test Error";
+            var catalogedError = new CatalogedError('0001','exampleLocal', messageText);
+            var message = MC.getCatalogedErrorMessage(catalogedError, 'en');
+            expect(message.message).to.equal('This is an example message');
+            expect(message.action).to.equal('Write a real message');
+        });
+        it('returns a message in French when language is "fr"', function() {
+            var messageText = "Test Error";
+            var catalogedError = new CatalogedError('0001','exampleLocal', messageText);
+            var message = MC.getCatalogedErrorMessage(catalogedError, 'fr');
+            expect(message.message).to.equal('This is an example message for french catalog');
+        });
+        it('returns a message in German when language is "de"', function() {
+            var messageText = "Test Error";
+            var catalogedError = new CatalogedError('0002','exampleLocal', messageText, {id: 'test-id'});
+            var message = MC.getCatalogedErrorMessage(catalogedError, 'de');
+            expect(message.message).to.equal('This is an example message with a special insert test-id, in german locale');
+        });
+        it('returns a message in Japanese when language is "jp"', function() {
+            var messageText = "Test Error";
+            var catalogedError = new CatalogedError('0001','exampleLocal', messageText);
+            var message = MC.getCatalogedErrorMessage(catalogedError, 'jp');
+            expect(message.message).to.equal('This is an example message for japanese catalog');
+        });
+        it('falls back to English when language is not available', function() {
+            var messageText = "Test Error";
+            var catalogedError = new CatalogedError('0001','exampleLocal', messageText);
+            var message = MC.getCatalogedErrorMessage(catalogedError, 'es');
+            expect(message.message).to.equal('This is an example message');
+        });
+        it('falls back to English for message not in specified language', function() {
+            var messageText = "Test Error";
+            var catalogedError = new CatalogedError('0004','exampleLocal', messageText);
+            var message = MC.getCatalogedErrorMessage(catalogedError, 'de');
+            expect(message.message).to.equal('This is a message only in the default catalog');
+        });
+        it('returns a message with inserts in specified language', function() {
+            var messageText = "Test Error with inserts";
+            var messageInserts = ['eins', '2', 'drei'];
+            var catalogedError = new CatalogedError('0003','exampleLocal', messageText, {}, messageInserts);
+            var message = MC.getCatalogedErrorMessage(catalogedError, 'de');
+            expect(message.message).to.equal("This is an example message with positional inserts eins 2 drei, in german locale");
+        });
+        it('returns a message with named inserts in specified language', function() {
+            var messageText = "Test Error with named inserts";
+            var catalogedError = new CatalogedError('0002','exampleLocal', messageText, {id: 'test-id-fr', number: 42, boolean: true});
+            var message = MC.getCatalogedErrorMessage(catalogedError, 'fr');
+            expect(message.message).to.equal('This is an example message with special inserts test-id-fr - 42 - true, in french locale');
+        });
     });
 
     describe('applyInserts', function () {


### PR DESCRIPTION
## 🌍 Overview

This PR adds support for language parameters in the message catalog manager, enabling error messages to be displayed in the user's preferred language. This is part of a larger multi-language support initiative across the AppConnect platform.

## 📋 Summary

- **Type**: Feature Enhancement
- **Impact**: Non-breaking change (fully backward compatible)

## 🎯 Motivation

Currently, all error messages are displayed in English regardless of the user's language preference. This PR enables the system to:
1. Accept language parameters from upstream services
2. Look up messages in language-specific catalogs
3. Fall back to English if translations are unavailable
4. Maintain full backward compatibility with existing implementations

## 📝 Changes Made

### 1. Updated `lib/middleware/errorMiddleware.js`

**Added optional `language` parameter to `formattingMiddleware()` function:**

```javascript
// Before
function formattingMiddleware(catalogIndex, preProcessorFunction)

// After
function formattingMiddleware(catalogIndex, preProcessorFunction, language)
```

**Changes:**
- Added `language` parameter (optional, defaults to 'en')
- Pass language to `getCatalogedErrorMessage()` method

**Usage Example:**
```javascript
const middleware = formattingMiddleware(
    catalogIndex,
    preprocessor,
    'fr'  // French
);
```

### 2. Updated `lib/message-catalog-manager.js`

**Added optional `language` parameter to `getCatalogedErrorMessage()` method:**

```javascript
// Before
MessageCatalogManager.prototype.getCatalogedErrorMessage = function (catalogedError)

// After
MessageCatalogManager.prototype.getCatalogedErrorMessage = function (catalogedError, language)
```

**Changes:**
-  Added `language` parameter (optional, defaults to 'en')
-  Pass language through to `getMessage()` method

**Note:** The existing `getMessage()` method  already supported language parameters, so no changes were needed there.